### PR TITLE
Invalid client fix

### DIFF
--- a/addons/sourcemod/scripting/BotUpgrades.sp
+++ b/addons/sourcemod/scripting/BotUpgrades.sp
@@ -39,6 +39,10 @@ public void OnMapStart() {
 public Action Event_PostInventory(Event event, const char[] name, bool dontBroadcast)
 {
 	int client = GetClientOfUserId(event.GetInt("userid"));
+	
+	if (!client)
+		return Plugin_Continue;
+	
 	ApplyAttributesToClient(client);
 
 	return Plugin_Continue;
@@ -68,7 +72,12 @@ public Action Event_PlayerSpawn(Event event, const char[] name, bool dontBroadca
 
 public Action Timer_PlayerSpawn(Handle timer, int userid)
 {
-	ApplyAttributesToClient(GetClientOfUserId(userid));
+	int client = GetClientOfUserId(userid);
+	
+	if (!client)
+		return Plugin_Stop;
+	
+	ApplyAttributesToClient();
 	return Plugin_Stop;
 }
 

--- a/addons/sourcemod/scripting/BotUpgrades.sp
+++ b/addons/sourcemod/scripting/BotUpgrades.sp
@@ -77,7 +77,7 @@ public Action Timer_PlayerSpawn(Handle timer, int userid)
 	if (!client)
 		return Plugin_Stop;
 	
-	ApplyAttributesToClient();
+	ApplyAttributesToClient(client);
 	return Plugin_Stop;
 }
 


### PR DESCRIPTION
[GetClientOfUserId](https://sourcemod.dev/#/clients/function.GetClientOfUserId) returns 0 when called with an invalid userid.
The return value should always be checked, specially on timers.
Fixes Client index 0 is invalid error.
![image](https://github.com/CombineSlayer24/TF2-MvM-Bot-Upgrades/assets/10157643/48ce0786-8fef-45d3-a4e9-66d0fc375c0a)
